### PR TITLE
Terraforged datapack for modded ore compatibility

### DIFF
--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/bauxite.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/bauxite.json
@@ -2,7 +2,7 @@
     "match": [
       [
         "minecraft:ore",
-		"immersiveengineering:bauxite_ore"
+		"immersiveengineering:ore_aluminum"
       ]
     ],
     "replace": {
@@ -14,7 +14,7 @@
             "size": 4,
             "target": "wg_stone",
             "state": {
-              "Name": "immersiveengineering:bauxite_ore"
+              "Name": "immersiveengineering:ore_aluminum"
             }
           }
         },

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/bauxite.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/bauxite.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"immersiveengineering:bauxite_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 4,
+            "target": "wg_stone",
+            "state": {
+              "Name": "immersiveengineering:bauxite_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 8,
+            "bottom_offset": 40,
+            "top_offset": 0,
+            "maximum": 45
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/bismuth.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/bismuth.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"silents_mechanisms:bismuth_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 8,
+            "target": "wg_stone",
+            "state": {
+              "Name": "silents_mechanisms:bismuth_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 4,
+            "bottom_offset": 16,
+            "top_offset": 0,
+            "maximum": 48
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/copper.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/copper.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"create:copper_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 12,
+            "target": "wg_stone",
+            "state": {
+              "Name": "create:copper_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 3,
+            "bottom_offset": 40,
+            "top_offset": 0,
+            "maximum": 46
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/lead.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/lead.json
@@ -2,7 +2,7 @@
     "match": [
       [
         "minecraft:ore",
-		"immersiveengineering:lead_ore"
+		"immersiveengineering:ore_lead"
       ]
     ],
     "replace": {
@@ -14,7 +14,7 @@
             "size": 6,
             "target": "wg_stone",
             "state": {
-              "Name": "immersiveengineering:lead_ore"
+              "Name": "immersiveengineering:ore_lead"
             }
           }
         },

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/lead.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/lead.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"immersiveengineering:lead_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 6,
+            "target": "wg_stone",
+            "state": {
+              "Name": "immersiveengineering:lead_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 4,
+            "bottom_offset": 8,
+            "top_offset": 0,
+            "maximum": 28
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/nickel.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/nickel.json
@@ -2,7 +2,7 @@
     "match": [
       [
         "minecraft:ore",
-		"immersiveengineering:nickel_ore"
+		"immersiveengineering:ore_nickel"
       ]
     ],
     "replace": {
@@ -14,7 +14,7 @@
             "size": 6,
             "target": "wg_stone",
             "state": {
-              "Name": "immersiveengineering:nickel_ore"
+              "Name": "immersiveengineering:ore_nickel"
             }
           }
         },

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/nickel.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/nickel.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"immersiveengineering:nickel_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 6,
+            "target": "wg_stone",
+            "state": {
+              "Name": "immersiveengineering:nickel_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 2,
+            "bottom_offset": 8,
+            "top_offset": 0,
+            "maximum": 16
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/osmium.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/osmium.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"mekanism:osmium_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 8,
+            "target": "wg_stone",
+            "state": {
+              "Name": "mekanism:osmium_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 12,
+            "bottom_offset": 0,
+            "top_offset": 0,
+            "maximum": 60
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/platinum.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/platinum.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"silents_mechanisms:platinum_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 8,
+            "target": "wg_stone",
+            "state": {
+              "Name": "silents_mechanisms:platinum_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 1,
+            "bottom_offset": 5,
+            "top_offset": 0,
+            "maximum": 15
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/silver.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/silver.json
@@ -11,7 +11,7 @@
         "feature": {
           "name": "minecraft:ore",
           "config": {
-            "size": 4,
+            "size": 8,
             "target": "wg_stone",
             "state": {
               "Name": "immersiveengineering:ore_silver"

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/silver.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/silver.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"immersiveengineering:silver_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 4,
+            "target": "wg_stone",
+            "state": {
+              "Name": "immersiveengineering:silver_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 4,
+            "bottom_offset": 8,
+            "top_offset": 0,
+            "maximum": 32
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/silver.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/silver.json
@@ -2,7 +2,7 @@
     "match": [
       [
         "minecraft:ore",
-		"immersiveengineering:silver_ore"
+		"immersiveengineering:ore_silver"
       ]
     ],
     "replace": {
@@ -14,7 +14,7 @@
             "size": 4,
             "target": "wg_stone",
             "state": {
-              "Name": "immersiveengineering:silver_ore"
+              "Name": "immersiveengineering:ore_silver"
             }
           }
         },

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/tin.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/tin.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"mekanism:tin_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 8,
+            "target": "wg_stone",
+            "state": {
+              "Name": "mekanism:tin_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 14,
+            "bottom_offset": 0,
+            "top_offset": 0,
+            "maximum": 60
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/uranium.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/uranium.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"immersiveengineering:uranium_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 4,
+            "target": "wg_stone",
+            "state": {
+              "Name": "immersiveengineering:uranium_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 2,
+            "bottom_offset": 8,
+            "top_offset": 0,
+            "maximum": 16
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/uranium.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/uranium.json
@@ -2,7 +2,7 @@
     "match": [
       [
         "minecraft:ore",
-		"immersiveengineering:uranium_ore"
+		"immersiveengineering:ore_uranium"
       ]
     ],
     "replace": {
@@ -14,7 +14,7 @@
             "size": 4,
             "target": "wg_stone",
             "state": {
-              "Name": "immersiveengineering:uranium_ore"
+              "Name": "immersiveengineering:ore_uranium"
             }
           }
         },

--- a/config/terraforged/datapacks/ores/data/terraforged/features/ores/zinc.json
+++ b/config/terraforged/datapacks/ores/data/terraforged/features/ores/zinc.json
@@ -1,0 +1,32 @@
+{
+    "match": [
+      [
+        "minecraft:ore",
+		"create:zinc_ore"
+      ]
+    ],
+    "replace": {
+      "name": "minecraft:decorated",
+      "config": {
+        "feature": {
+          "name": "minecraft:ore",
+          "config": {
+            "size": 14,
+            "target": "wg_stone",
+            "state": {
+              "Name": "create:zinc_ore"
+            }
+          }
+        },
+        "decorator": {
+          "name": "minecraft:count_range",
+          "config": {
+            "count": 4,
+            "bottom_offset": 15,
+            "top_offset": 0,
+            "maximum": 55
+          }
+        }
+      }
+    }
+  }

--- a/config/terraforged/datapacks/ores/pack.mcmeta
+++ b/config/terraforged/datapacks/ores/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 5,
+    "description": "Ore Data Pack"
+  }
+}


### PR DESCRIPTION
This is a proposed solution to #52, tested on Terraforged 0.0.15/Valhelsia 2.2.6

This datapack uses decorator injectors similarly to how it is done with vanilla ores to ensure they generate even in Terraforged strata decorators. See: https://github.com/TerraForged/TerraForged/tree/master/src/main/resources/data/terraforged/features/ores

I have tested it by generating a new world with a specific seed with/without the datapack and using world edit to remove everything except ores from specific chunks and observing whether modded ores were generated in strata layers containing modded stone. Without the datapack, there seem to be big issues with ores in upper strata especially copper, but with this datapack, the ores were generating properly with copper and bismuth especially finally appearing in strata containing dolomite or jasper or scoria.

I left out the Druidcraft and Forbidden/Arcanus ores because their config files do not specify how commonly they should appear or at what levels they should appear, but this includes the ores for the important tech mods including Create, Mekanism, Immersive Engineering, and Silent's Mechanisms

Here's some data on how many ores there are average in 10 chunks in different scenarios

**Turning strata off(baseline):**
Strata = Off | Datapack = Off
-------------|--------------
Copper | 453
Zinc | 478
Bauxite | 127
Lead | 136
Nickel | 71
Silver | 199
Uranium | 48
Platinum | 39
Bismuth | 166
Tin | 550
Osmium | 519
Diamond | 40

**Old default(almost no modded ores at all):**
Strata = ON | Datapack = Off | Change
-------------|--------------|------------
Copper | 92 | (-80%)
Zinc | 138 | (-71%)
Bauxite | 8  |(-94%)
Lead | 64 | (-53%)
Nickel | 17 | (-76%)
Silver | 94 | (-53%)
Uranium | 8 | (-83%)
Platinum | 13 | (-67%)
Bismuth | 52 | (-69%)
Tin | 232 | (-58%)
Osmium | 235 | (-55%)
Diamond | 41

**Leaving strata on and enabling this change:**
Strata = ON | Datapack = ON | Change
-------------|--------------|----------
Copper | 340 | (-25%)
Zinc | 535 | (+12%)
Bauxite | 153 | (+20%)
Lead | 150 | (+10%)
Nickel | 79 | (+11%)
Silver | 158 | (-20%)
Uranium | 51 | (+6%)
Platinum | 46 | (+18%)
Bismuth | 196 | (+18%)
Tin | 660 | (+20%)
Osmium | 576 | (+11%)
Diamond | 44

**Validating with strata off:**
Strata = Off | Datapack = ON
-------------|--------------
Copper | 276
Zinc | 478
Bauxite | 127
Lead | 136
Nickel | 71
Silver | 146
Uranium | 48
Platinum | 39
Bismuth | 167
Tin | 559
Osmium | 522
Diamond | 43

The alternative would be to just turn off strata decorators in the default config for terraforged (terraforged/terraforged-generator.json), which would be easier to maintain going forward, and results in much more vanilla stone generating, but has the disadvantage of not having the more realistic rock strata underground.