### PR TITLE
Add treated wood recipe

### DIFF
--- a/openloader/data/Valhelsia_3-Recipes/data/immersiveengineering/recipes/crafting/treated_wood_horizontal.json
+++ b/openloader/data/Valhelsia_3-Recipes/data/immersiveengineering/recipes/crafting/treated_wood_horizontal.json
@@ -1,0 +1,20 @@
+{
+	"type": "minecraft:crafting_shaped",
+	"pattern": [
+		"###",
+		"#W#",
+		"###"
+	],
+	"key": {
+		"#": {
+			"tag": "minecraft:planks"
+		},
+		"W": {
+			"item": "immersiveengineering:creosote_bucket"
+		}
+	},
+	"result": {
+		"item": "immersiveengineering:treated_wood_horizontal",
+		"count": 8
+	}
+}


### PR DESCRIPTION
There is a bug in kubejs that cause treated wood recipe to be missing. Done a work around to fix it