### PR TITLE
fix oregen for voidstone

### DIFF
--- a/config/quark-common.toml
+++ b/config/quark-common.toml
@@ -800,7 +800,7 @@
 				"Cluster Size" = 33
 
 			[world.new_stone_types.voidstone.dimensions]
-				Dimensions = ["minecraft:the_nether"]
+				Dimensions = ["minecraft:the_end"]
 				"Is Blacklist" = false
 
 		[world.new_stone_types.slate]


### PR DESCRIPTION
voidstone does not currently generate in the end, like it should

voidstone _was_ "basalt" and it generated in the nether prior to v1.16, so this is likely leftover from an old config and was missed?