### PR TITLE
Add Redstone Quartz process to Mekanism & minor fixes

### DIFF
--- a/kubejs/assets/valhelsia/lang/en_us.json
+++ b/kubejs/assets/valhelsia/lang/en_us.json
@@ -9,7 +9,7 @@
   "sdrp.the_end": "The End",
   "sdrp.yamda_dim.in": "In YAMDA Mining Dim",
   "sdrp.yamda_dim": "Mining Dim",
-
+  
   "comment.items": "---Items with missing or incorrect language entries---",
   "item.minecraft.potion.effect.serepdipity": "Potion of Serendipity",
   "item.minecraft.splash_potion.effect.serepdipity": "Splash Potion of Serendipity",
@@ -34,4 +34,5 @@
   "entity.minecraft.villager.immersiveengineering.electrician": "Electrician",
   "entity.minecraft.villager.immersiveengineering.outfitter": "Outfitter",
   "entity.minecraft.villager.immersiveengineering.gunsmith": "Gunsmith"
+
 }

--- a/kubejs/assets/valhelsia/lang/en_us.json
+++ b/kubejs/assets/valhelsia/lang/en_us.json
@@ -9,7 +9,7 @@
   "sdrp.the_end": "The End",
   "sdrp.yamda_dim.in": "In YAMDA Mining Dim",
   "sdrp.yamda_dim": "Mining Dim",
-  
+
   "comment.items": "---Items with missing or incorrect language entries---",
   "item.minecraft.potion.effect.serepdipity": "Potion of Serendipity",
   "item.minecraft.splash_potion.effect.serepdipity": "Splash Potion of Serendipity",
@@ -23,6 +23,7 @@
   "comment.enchantment.descriptions": "---Enchantments with missing descriptions---",
   "enchantment.forbidden_arcanus.permafrost.desc": "Allows an Edelwood Bucket to safely carry lava.",
   "enchantment.forbidden_arcanus.indestructible.desc": "Prevents the item from losing durability while carried by a player.",
+  "enchantment.minecolonies.raider_damage_enchant.desc": "Increases damage dealt to Raider mobs",
 
   "comment.entities": "---Entities with missing or incorrect language entries---",
   "entity.minecraft.villager.apiarist": "Apiarist",
@@ -33,5 +34,4 @@
   "entity.minecraft.villager.immersiveengineering.electrician": "Electrician",
   "entity.minecraft.villager.immersiveengineering.outfitter": "Outfitter",
   "entity.minecraft.villager.immersiveengineering.gunsmith": "Gunsmith"
-
 }

--- a/kubejs/server_scripts/recipes/mekanism.js
+++ b/kubejs/server_scripts/recipes/mekanism.js
@@ -49,7 +49,7 @@ events.listen('recipes', function (event) {
   infusionConversion('mekanism:carbon', '#forge:dusts/coal_coke', 40)
 
   // Quark
-  colors.forEach(function (element) {
+  colors.forEach(function(element) {
     // Stained Planks - get double the planks for the same amount of dye.
     event.recipes.mekanism.combining(Item.of(`quark:${element}_stained_planks`, 16), Item.of(`#minecraft:planks`, 16), `#forge:dyes/${element}`)
   })

--- a/kubejs/server_scripts/recipes/mekanism.js
+++ b/kubejs/server_scripts/recipes/mekanism.js
@@ -61,6 +61,6 @@ events.listen('recipes', function (event) {
   event.recipes.mekanism.combining(Item.of('upgrade_aquatic:tongue_kelp', 8), Item.of('minecraft:kelp', 8), '#forge:dyes/red')
 
   // Create
-  event.recipes.mekanism.metallurgic_infusing('create:rose_quartz', 'minecraft:nether_quartz', 'mekanism:redstone', 80) // 1 redstone = 10. Keeping in line w/ manual recipe
-  event.recipes.mekanism.combining(Item.of('create:polished_redstone_quartz', 8), Item.of('create:rose_quartz', 8), '#forge:sandstone')
+  event.recipes.mekanism.metallurgic_infusing('create:rose_quartz', 'minecraft:quartz', 'mekanism:redstone', 80) // 1 redstone = 10. Keeping in line w/ manual recipe
+  event.recipes.mekanism.combining(Item.of('create:polished_rose_quartz', 8), Item.of('create:rose_quartz', 8), '#forge:sandstone')
 })

--- a/kubejs/server_scripts/recipes/mekanism.js
+++ b/kubejs/server_scripts/recipes/mekanism.js
@@ -49,7 +49,7 @@ events.listen('recipes', function (event) {
   infusionConversion('mekanism:carbon', '#forge:dusts/coal_coke', 40)
 
   // Quark
-  colors.forEach(function(element) {
+  colors.forEach(function (element) {
     // Stained Planks - get double the planks for the same amount of dye.
     event.recipes.mekanism.combining(Item.of(`quark:${element}_stained_planks`, 16), Item.of(`#minecraft:planks`, 16), `#forge:dyes/${element}`)
   })
@@ -60,4 +60,7 @@ events.listen('recipes', function (event) {
   event.recipes.mekanism.combining(Item.of('upgrade_aquatic:thorny_kelp', 8), Item.of('minecraft:kelp', 8), '#forge:dyes/brown')
   event.recipes.mekanism.combining(Item.of('upgrade_aquatic:tongue_kelp', 8), Item.of('minecraft:kelp', 8), '#forge:dyes/red')
 
+  // Create
+  event.recipes.mekanism.metallurgic_infusing('create:rose_quartz', 'minecraft:nether_quartz', 'mekanism:redstone', 80) // 1 redstone = 10. Keeping in line w/ manual recipe
+  event.recipes.mekanism.combining(Item.of('create:polished_redstone_quartz', 8), Item.of('create:rose_quartz', 8), '#forge:sandstone')
 })

--- a/kubejs/server_scripts/recipes/replace.js
+++ b/kubejs/server_scripts/recipes/replace.js
@@ -14,4 +14,8 @@ events.listen('recipes', function (event) {
   // Allow Mekanism's Obsidian Dust to be used to make Chromatic Compound.
   event.replaceInput({}, 'create:powdered_obsidian', '#forge:dusts/obsidian')
 
+  // Dragon Scale
+  event.replaceInput({}, 'forbidden_arcanus:dragon_scale', '#forge:dragon_scales')
+  event.replaceInput({}, 'quark:dragon_scale', '#forge:dragon_scales')
+
 })

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -91,7 +91,7 @@ onEvent('item.tags', event => {
     'tetra:modular_shield'
   ]
   event.get('forbidden_arcanus:indestructible_blacklisted').add(indestructibleBlacklisted)
-  
+
   // Missing Wall Tags
   var woodenWalls = [
     'absentbydesign:wall_stripped_acacia_log',
@@ -171,10 +171,10 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:walls')
-       .add(woodenWalls)
-       .add(stoneWalls)
-       .add(glassWalls)
-       .add(miscWalls)
+    .add(woodenWalls)
+    .add(stoneWalls)
+    .add(glassWalls)
+    .add(miscWalls)
 
   // Missing Stair Tags
   var woodenStairs = [
@@ -236,7 +236,7 @@ onEvent('item.tags', event => {
     'absentbydesign:stairs_wool_white',
     'absentbydesign:stairs_wool_yellow'
   ]
-  
+
   var terracottaStairs = [
     'absentbydesign:stairs_terracotta_black',
     'absentbydesign:stairs_terracotta_blue',
@@ -285,13 +285,13 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:stairs')
-       .add(woodenStairs)
-       .add(stoneStairs)
-       .add(concreteStairs)
-       .add(woolStairs)
-       .add(terracottaStairs)
-       .add(glassStairs)
-       .add(miscStairs)
+    .add(woodenStairs)
+    .add(stoneStairs)
+    .add(concreteStairs)
+    .add(woolStairs)
+    .add(terracottaStairs)
+    .add(glassStairs)
+    .add(miscStairs)
 
   // Missing Slab Tags
   var woodenSlabs = [
@@ -402,18 +402,18 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:slabs')
-       .add(woodenSlabs)
-       .add(stoneSlabs)
-       .add(concreteSlabs)
-       .add(woolSlabs)
-       .add(terracottaSlabs)
-       .add(glassSlabs)
-       .add(miscSlabs)
+    .add(woodenSlabs)
+    .add(stoneSlabs)
+    .add(concreteSlabs)
+    .add(woolSlabs)
+    .add(terracottaSlabs)
+    .add(glassSlabs)
+    .add(miscSlabs)
 
   event.get('minecraft:wooden_slabs')
-       .add(woodenSlabs)
+    .add(woodenSlabs)
 
-       
+
   // Sandstone Tags
   var aridSandstones = [
     'atmospheric:arid_sandstone',
@@ -424,7 +424,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/arid')
-       .add(aridSandstones)
+    .add(aridSandstones)
 
   var redAridSandstones = [
     'atmospheric:red_arid_sandstone',
@@ -435,7 +435,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/red_arid')
-       .add(redAridSandstones)
+    .add(redAridSandstones)
 
   var orangeSandstones = [
     'biomesoplenty:orange_sandstone',
@@ -445,7 +445,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/orange')
-       .add(orangeSandstones)
+    .add(orangeSandstones)
 
   var whiteSandstones = [
     'biomesoplenty:white_sandstone',
@@ -455,7 +455,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/white')
-       .add(whiteSandstones)
+    .add(whiteSandstones)
 
   var blackSandstones = [
     'biomesoplenty:black_sandstone',
@@ -465,7 +465,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/black')
-       .add(blackSandstones)
+    .add(blackSandstones)
 
   var soulSandstones = [
     'quark:soul_sandstone',
@@ -476,9 +476,9 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/soul')
-       .add(soulSandstones)
+    .add(soulSandstones)
 
-     
+
   var soullessSandstones = [
     'forbidden_arcanus:soulless_sandstone',
     'forbidden_arcanus:cut_soulless_sandstone',
@@ -486,7 +486,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/soulless')
-       .add(soullessSandstones)
+    .add(soullessSandstones)
 
   event.add('forge:sandstone/colorless', 'quark:sandstone_bricks')
   event.add('forge:sandstone/red', 'quark:red_sandstone_bricks')
@@ -500,9 +500,9 @@ onEvent('item.tags', event => {
     'tetra:modular_crossbow',
     'tetra:modular_shield'
   ]
-  
+
   event.get('industrialforegoing:enchantment_extractor_blacklist')
-       .add(enchantmentExtractorBlacklist)
+    .add(enchantmentExtractorBlacklist)
 
   // Missing Create Crushed Ore Tags (for JAOPCA compatibility in recipes)
   event.add('create:crushed_ores/iron', 'create:crushed_iron_ore')
@@ -551,10 +551,11 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:beacon_payment_items')
-       .add(beaconPaymentItems)
-  
+    .add(beaconPaymentItems)
+
   // Misc Missing Item Tags
   event.add('forge:seeds/aubergine', 'mysticalworld:aubergine_seeds')
   event.add('forge:dusts/obsidian', 'create:powdered_obsidian')
   event.add('forbidden_arcanus:edelwood_logs', 'forbidden_arcanus:edelwood_log')
+  event.add('forge:dragon_scales', 'quark:dragon_scales')
 })

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -91,7 +91,7 @@ onEvent('item.tags', event => {
     'tetra:modular_shield'
   ]
   event.get('forbidden_arcanus:indestructible_blacklisted').add(indestructibleBlacklisted)
-
+  
   // Missing Wall Tags
   var woodenWalls = [
     'absentbydesign:wall_stripped_acacia_log',
@@ -171,10 +171,10 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:walls')
-    .add(woodenWalls)
-    .add(stoneWalls)
-    .add(glassWalls)
-    .add(miscWalls)
+       .add(woodenWalls)
+       .add(stoneWalls)
+       .add(glassWalls)
+       .add(miscWalls)
 
   // Missing Stair Tags
   var woodenStairs = [
@@ -236,7 +236,7 @@ onEvent('item.tags', event => {
     'absentbydesign:stairs_wool_white',
     'absentbydesign:stairs_wool_yellow'
   ]
-
+  
   var terracottaStairs = [
     'absentbydesign:stairs_terracotta_black',
     'absentbydesign:stairs_terracotta_blue',
@@ -285,13 +285,13 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:stairs')
-    .add(woodenStairs)
-    .add(stoneStairs)
-    .add(concreteStairs)
-    .add(woolStairs)
-    .add(terracottaStairs)
-    .add(glassStairs)
-    .add(miscStairs)
+       .add(woodenStairs)
+       .add(stoneStairs)
+       .add(concreteStairs)
+       .add(woolStairs)
+       .add(terracottaStairs)
+       .add(glassStairs)
+       .add(miscStairs)
 
   // Missing Slab Tags
   var woodenSlabs = [
@@ -402,18 +402,18 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:slabs')
-    .add(woodenSlabs)
-    .add(stoneSlabs)
-    .add(concreteSlabs)
-    .add(woolSlabs)
-    .add(terracottaSlabs)
-    .add(glassSlabs)
-    .add(miscSlabs)
+       .add(woodenSlabs)
+       .add(stoneSlabs)
+       .add(concreteSlabs)
+       .add(woolSlabs)
+       .add(terracottaSlabs)
+       .add(glassSlabs)
+       .add(miscSlabs)
 
   event.get('minecraft:wooden_slabs')
-    .add(woodenSlabs)
+       .add(woodenSlabs)
 
-
+       
   // Sandstone Tags
   var aridSandstones = [
     'atmospheric:arid_sandstone',
@@ -424,7 +424,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/arid')
-    .add(aridSandstones)
+       .add(aridSandstones)
 
   var redAridSandstones = [
     'atmospheric:red_arid_sandstone',
@@ -435,7 +435,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/red_arid')
-    .add(redAridSandstones)
+       .add(redAridSandstones)
 
   var orangeSandstones = [
     'biomesoplenty:orange_sandstone',
@@ -445,7 +445,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/orange')
-    .add(orangeSandstones)
+       .add(orangeSandstones)
 
   var whiteSandstones = [
     'biomesoplenty:white_sandstone',
@@ -455,7 +455,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/white')
-    .add(whiteSandstones)
+       .add(whiteSandstones)
 
   var blackSandstones = [
     'biomesoplenty:black_sandstone',
@@ -465,7 +465,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/black')
-    .add(blackSandstones)
+       .add(blackSandstones)
 
   var soulSandstones = [
     'quark:soul_sandstone',
@@ -476,9 +476,9 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/soul')
-    .add(soulSandstones)
+       .add(soulSandstones)
 
-
+     
   var soullessSandstones = [
     'forbidden_arcanus:soulless_sandstone',
     'forbidden_arcanus:cut_soulless_sandstone',
@@ -486,7 +486,7 @@ onEvent('item.tags', event => {
   ]
 
   event.get('forge:sandstone/soulless')
-    .add(soullessSandstones)
+       .add(soullessSandstones)
 
   event.add('forge:sandstone/colorless', 'quark:sandstone_bricks')
   event.add('forge:sandstone/red', 'quark:red_sandstone_bricks')
@@ -500,9 +500,9 @@ onEvent('item.tags', event => {
     'tetra:modular_crossbow',
     'tetra:modular_shield'
   ]
-
+  
   event.get('industrialforegoing:enchantment_extractor_blacklist')
-    .add(enchantmentExtractorBlacklist)
+       .add(enchantmentExtractorBlacklist)
 
   // Missing Create Crushed Ore Tags (for JAOPCA compatibility in recipes)
   event.add('create:crushed_ores/iron', 'create:crushed_iron_ore')
@@ -551,8 +551,8 @@ onEvent('item.tags', event => {
   ]
 
   event.get('minecraft:beacon_payment_items')
-    .add(beaconPaymentItems)
-
+       .add(beaconPaymentItems)
+  
   // Misc Missing Item Tags
   event.add('forge:seeds/aubergine', 'mysticalworld:aubergine_seeds')
   event.add('forge:dusts/obsidian', 'create:powdered_obsidian')


### PR DESCRIPTION
(Hope I'm not offending anyone, I couldn't find anywhere else to contact devs/guidelines for contributing)

1) A quick recipe suggestion for Mekanism to allow for an alternative way to create/process redstone quartz that isn't as manual
2) Raider's Bane seems to be lacking a description so that was just a quick addition
3) Realized that Dragon Scales from Quark are not usable for FA content and given how scale-hungry FA content is, it only seemed natural to streamline those