### PR TITLE
Twilight Forest missing tags

### DIFF
--- a/kubejs/assets/valhelsia/lang/en_us.json
+++ b/kubejs/assets/valhelsia/lang/en_us.json
@@ -24,6 +24,8 @@
   "enchantment.forbidden_arcanus.permafrost.desc": "Allows an Edelwood Bucket to safely carry lava.",
   "enchantment.forbidden_arcanus.indestructible.desc": "Prevents the item from losing durability while carried by a player.",
   "enchantment.minecolonies.raider_damage_enchant.desc": "Increases damage dealt to Raider mobs",
+  "enchantment.twilightforest.chill_aura.desc": "Slows attackers",
+  "enchantment.twilightforest.fiery_react": "Burns attackers",
 
   "comment.entities": "---Entities with missing or incorrect language entries---",
   "entity.minecraft.villager.apiarist": "Apiarist",

--- a/kubejs/server_scripts/tags/item_tags.js
+++ b/kubejs/server_scripts/tags/item_tags.js
@@ -70,8 +70,19 @@ onEvent('item.tags', event => {
     'druidcraft:darkwood_sapling',
     'druidcraft:elder_sapling',
     'forbidden_arcanus:cherrywood_sapling',
-    'forbidden_arcanus:mysterywood_sapling'
+    'forbidden_arcanus:mysterywood_sapling',
+    'twilightforest:rainbow_oak_sapling',
+    'twilightforest:twilight_oak_sapling',
+    'twilightforest:canopy_sapling',
+    'twilightforest:mangrove_sapling',
+    'twilightforest:darkwood_sapling',
+    'twilightforest:hollow_oak_sapling',
+    'twilightforest:time_sapling',
+    'twilightforest:transformation_sapling',
+    'twilightforest:mining_sapling',
+    'twilightforest:sorting_sapling'
   ]
+
   event.get('forge:sapling').add(saplings)
 
   // Missing #minecraft:logs_that_burn item tags.
@@ -88,7 +99,8 @@ onEvent('item.tags', event => {
     'tetra:modular_double',
     'tetra:modular_bow',
     'tetra:modular_crossbow',
-    'tetra:modular_shield'
+    'tetra:modular_shield',
+    'twilightforest:glass_sword' // Has one durability, meant to be a one use item
   ]
   event.get('forbidden_arcanus:indestructible_blacklisted').add(indestructibleBlacklisted)
   
@@ -547,12 +559,27 @@ onEvent('item.tags', event => {
     'immersiveengineering:ingot_nickel',
     'immersiveengineering:ingot_constantan',
     'immersiveengineering:ingot_electrum',
-    'mysticalworld:quicksilver_ingot'
+    'mysticalworld:quicksilver_ingot',
+    'twilightforest:ironwood_ingot',
+    'twilightforest:fiery_ingot',
+    'twilightforest:knightmetal_ingot'
   ]
 
   event.get('minecraft:beacon_payment_items')
        .add(beaconPaymentItems)
   
+  // Missing curios charm tags
+  var curioCharmItems = [
+    "twilightforest:charm_of_life_1",
+    "twilightforest:charm_of_life_2",
+    "twilightforest:charm_of_keeping_1",
+    "twilightforest:charm_of_keeping_2",
+    "twilightforest:charm_of_keeping_3"
+  ]
+
+  event.get('curios:charm')
+       .add(curioCharmItems);
+
   // Misc Missing Item Tags
   event.add('forge:seeds/aubergine', 'mysticalworld:aubergine_seeds')
   event.add('forge:dusts/obsidian', 'create:powdered_obsidian')


### PR DESCRIPTION
Hope nobody minds, I saw you guys were preparing for Twilight Forest and we added it to our local a few days ago and figured I'd share some compatibility changes we added:

- The saplings were missing the forge/sapling tag
- Adding the new ingots as beacon-accepted items
- Making the five Charms that used to be in baubles charm slots compatible w/ curios charm slots
- Blacklisting the one sword from being indestructible